### PR TITLE
fix redirection of approved reviews in models & datasets

### DIFF
--- a/packages/pureml_frontend/app/routes/org/$orgId/datasets/$datasetId/review/approved/index.tsx
+++ b/packages/pureml_frontend/app/routes/org/$orgId/datasets/$datasetId/review/approved/index.tsx
@@ -54,7 +54,7 @@ export default function DatasetReview() {
                                 key={index}
                                 onClick={() => {
                                   navigate(
-                                    `/org/${reviewData.params.orgId}/datasets/${reviewData.params.datasetId}/versions/datalineage`
+                                    `/org/${reviewData.params.orgId}/datasets/${reviewData.params.datasetId}/versions/main/datalineage`
                                   );
                                 }}
                               >

--- a/packages/pureml_frontend/app/routes/org/$orgId/models/$modelId/review/approved/index.tsx
+++ b/packages/pureml_frontend/app/routes/org/$orgId/models/$modelId/review/approved/index.tsx
@@ -54,7 +54,7 @@ export default function ModelReview() {
                                 key={index}
                                 onClick={() => {
                                   navigate(
-                                    `/org/${reviewData.params.orgId}/models/${reviewData.params.modelId}/versions/logs`
+                                    `/org/${reviewData.params.orgId}/models/${reviewData.params.modelId}/versions/main/logs`
                                   );
                                 }}
                               >


### PR DESCRIPTION
Fixes: #183 

Fix redirection of approved reviews in models & datasets:
- Approved reviews in models will be navigated to `.../{model_name}/versions/main/logs`
- Approved reviews in datasets will be navigated to `.../{model_name}/versions/main/datalineage `
