### PR TITLE
Support for apt commands for docker container creation

### DIFF
--- a/packages/sdk/pureml/__init__.py
+++ b/packages/sdk/pureml/__init__.py
@@ -25,4 +25,4 @@ from .package import docker, fastapi
 from .schema import Input, Output
 from .predictor.predictor import BasePredictor
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pureml"
-version = "0.3.3"
+version = "0.3.4"
 description = ""
 license = "Apache-2.0"
 authors = ["vamsidhar muthireddy <vamsi.muthireddy@gmail.com>"]


### PR DESCRIPTION
Format for adding apt commands to docker container creation.

Example:
1. Create a list of commands that need to be run in the docker container.

`sys_commands = ['apt install -y ffmpeg', 'apt install -y vim']`

Here, we are giving commands to install `ffmpeg, vim` libraries in our docker container. 

**Note:** Add `-y` argument to the commands for silent execution of commands without waiting for interactive input while creating the image.

2. Passing the commands for docker container creation

```
import pureml

pureml.docker.create(label=<model_label>', 
                     org_id=<org_id>,
                     access_token=<access_token>,
                     sys_commands=sys_commands)

```
